### PR TITLE
Nickname mismatch fixed #1

### DIFF
--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -62,9 +62,12 @@ class UserService:
                 return None
             validated_data['hashed_password'] = hash_password(validated_data.pop('password'))
             new_user = User(**validated_data)
-            new_nickname = generate_nickname()
-            while await cls.get_by_nickname(session, new_nickname):
+            if validated_data["nickname"]:
+                new_nickname = validated_data['nickname']
+            else:
                 new_nickname = generate_nickname()
+                while await cls.get_by_nickname(session, new_nickname):
+                    new_nickname = generate_nickname()
             new_user.nickname = new_nickname
             logger.info(f"User Role: {new_user.role}")
             user_count = await cls.count(session)


### PR DESCRIPTION
Added a condition where if nickname is empty then we can generate the nickname or else the database will be entered with same nickname that is explicitly added in API request that is passed.